### PR TITLE
exclude protobuf 4.x dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@
 
 # Any dependency that appears in more than once recipe should be
 # encapsulated as a variable to ensure consistent pinning.
-{% set protobuf_dep   = "protobuf >=3.19,<5.0a0" %}
+{% set protobuf_dep   = "protobuf >=3.19,<4.0a0" %}
 {% set grpcio_dep     = "grpcio >=1.0.0,<2.0.0a0" %}
 {% set googleapis_dep = "googleapis-common-protos >=1.52,<2.0a0" %}
 {% set requests_dep   = "requests >=2.7,<3.0.0a0" %}
@@ -88,7 +88,7 @@ source:
     - grpcio-version.patch
 
 build:
-  number: 1
+  number: 2
   skip: true # [py<37]
 
 outputs:


### PR DESCRIPTION
snowflake dependency
rebuild for py311 beside this, fix for the bug  with locally installed protobuf > 4.0.
Error has happened on the test phase:
opentelemetry-exporter-opencensus 0.36b0 has requirement protobuf~=3.13, but you have protobuf 4.23.4