### PR TITLE
PKG-2688 rebuild for py311

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,8 +88,8 @@ source:
     - two-patches.patch
 
 build:
-  number: 2
-  skip: true # [py<36]
+  number: 3
+  skip: true # [py<37]
 
 outputs:
   - name: {{ name }}-api


### PR DESCRIPTION
We have to get back to 1.12.0 and rebuild it for python 3.11 as this is dependency for snowflake-telemetry-python
- create new main-1.12.0 branch
- bump up build number
- update python version