### PR TITLE
add upload_without_merge

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,5 @@ upload_channels:
 channels:
   - sfe1ed40
   - services
+
+upload_without_merge: True


### PR DESCRIPTION
We have to get back to 1.12.0 and rebuild it for python 3.11 as this is dependency for snowflake-telemetry-python

create new main-1.12.0 branch
bump up build number
update python version